### PR TITLE
Fix writing page header to match home and about page sizing

### DIFF
--- a/src/pages/writing/index.astro
+++ b/src/pages/writing/index.astro
@@ -102,8 +102,14 @@ const sortedByTitle = [...posts].sort(
 	}
 
 	h1 {
-		font-size: var(--text-3xl);
+		font-size: var(--text-2xl);
 		color: var(--gray-0);
+	}
+
+	@media (min-width: 60em) {
+		h1 {
+			font-size: var(--text-3xl);
+		}
 	}
 
 	.section-header {


### PR DESCRIPTION
Use responsive text-2xl/text-3xl pattern consistent with Hero and
AboutHero components instead of a fixed text-3xl at all breakpoints.

https://claude.ai/code/session_011fCk28Up3S7ndfUQTU4KtX