### PR TITLE
feat: reading progress bar and reading time on post pages

### DIFF
--- a/src/components/ReadingProgressBar.astro
+++ b/src/components/ReadingProgressBar.astro
@@ -1,0 +1,83 @@
+<div class="reading-progress-track" data-progress-bar>
+  <div class="reading-progress-bar"></div>
+</div>
+
+<style is:global>
+  .reading-progress-track {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 3px;
+    z-index: 10000;
+    pointer-events: none;
+  }
+
+  .reading-progress-bar {
+    height: 100%;
+    width: 0%;
+    background: linear-gradient(to right, var(--gray-999), var(--accent-regular));
+    position: relative;
+  }
+
+  .reading-progress-bar::after {
+    content: '';
+    position: absolute;
+    right: 0;
+    top: 0;
+    width: 3px;
+    height: 3px;
+    background: var(--gray-999);
+  }
+</style>
+
+<script>
+  let cleanup: (() => void) | null = null;
+
+  const init = () => {
+    cleanup?.();
+    cleanup = null;
+
+    const tracks = document.querySelectorAll<HTMLElement>('[data-progress-bar]');
+    if (tracks.length === 0) return;
+
+    // Keep the most recent track and discard duplicates left from prior swaps.
+    const track = tracks[tracks.length - 1];
+    tracks.forEach((t) => {
+      if (t !== track) t.remove();
+    });
+    if (track.parentElement !== document.body) {
+      document.body.appendChild(track);
+    }
+
+    const bar = track.querySelector<HTMLElement>('.reading-progress-bar');
+    if (!bar) return;
+
+    let ticking = false;
+    const onScroll = () => {
+      if (ticking) return;
+      ticking = true;
+      requestAnimationFrame(() => {
+        const scrollable = document.documentElement.scrollHeight - window.innerHeight;
+        if (scrollable <= 0) {
+          track.style.display = 'none';
+        } else {
+          track.style.display = '';
+          const progress = Math.min(100, (window.scrollY / scrollable) * 100);
+          bar.style.width = `${progress}%`;
+        }
+        ticking = false;
+      });
+    };
+
+    window.addEventListener('scroll', onScroll, { passive: true });
+    onScroll();
+
+    cleanup = () => {
+      window.removeEventListener('scroll', onScroll);
+    };
+  };
+
+  init();
+  document.addEventListener('astro:page-load', init);
+</script>

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection, render } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import ReadingProgressBar from '../../components/ReadingProgressBar.astro';
 import GatedContent from '../../components/work/GatedContent.tsx';
 import CaseStudyCarousel from '../../components/work/CaseStudyCarousel.tsx';
 
@@ -55,6 +56,7 @@ const meta = metaBySlug[entry.id] ?? { role: 'Lead Product Designer', collaborat
   description={entry.data.description}
   image={entry.data.img}
 >
+  <ReadingProgressBar />
   <main class="wrapper post-layout">
     <article>
       <header class="post-header">

--- a/src/pages/writing/[...slug].astro
+++ b/src/pages/writing/[...slug].astro
@@ -1,6 +1,8 @@
 ---
 import { getCollection, render } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import ReadingProgressBar from '../../components/ReadingProgressBar.astro';
+import { getReadingTime } from '../../utils/reading-time';
 
 export async function getStaticPaths() {
 	const posts = await getCollection('blog');
@@ -29,15 +31,21 @@ const formattedDate = post.data.publishDate.toLocaleDateString('en-US', {
 	day: 'numeric',
 	year: 'numeric',
 });
+
+const readingTime = getReadingTime(post.body ?? '');
 ---
 
 <BaseLayout title={`${post.data.title} | F Cary Snyder`} description={post.data.description} image={socialImage}>
+	<ReadingProgressBar />
 	<main class="wrapper post-layout">
 		<article>
 			<header class="post-header">
 				<a href="/writing/" class="back-link">&larr; Back</a>
 				<h1>{post.data.title}</h1>
-				<time datetime={post.data.publishDate.toISOString()}>{formattedDate}</time>
+				<div class="post-date-row">
+					<time datetime={post.data.publishDate.toISOString()}>{formattedDate}</time>
+					<span class="reading-time">·&nbsp; {readingTime} min read</span>
+				</div>
 			</header>
 
 			<div class="post-content">
@@ -114,7 +122,10 @@ const formattedDate = post.data.publishDate.toLocaleDateString('en-US', {
 		margin-bottom: 0.5rem;
 	}
 
-	.post-header time {
+	.post-date-row {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
 		font-family: var(--font-family-mono);
 		font-size: var(--font-size-sm);
 		color: var(--gray-400);

--- a/src/utils/reading-time.ts
+++ b/src/utils/reading-time.ts
@@ -1,0 +1,15 @@
+const WORDS_PER_MINUTE = 238;
+
+export function getReadingTime(text: string): number {
+  const stripped = text
+    .replace(/```[\s\S]*?```/g, '')
+    .replace(/`[^`]*`/g, '')
+    .replace(/^import\s.+from\s.+;?$/gm, '')
+    .replace(/<[^>]+>/g, '')
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, '')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/[#*_`\[\]()!>~|]/g, '');
+
+  const words = stripped.split(/\s+/).filter(Boolean);
+  return Math.max(1, Math.ceil(words.length / WORDS_PER_MINUTE));
+}


### PR DESCRIPTION
## Summary
- Adds a fixed-position scroll progress bar to writing and work post pages, plus a "min read" estimate next to the date on writing posts.
- Progress bar re-initializes on `astro:page-load` so it keeps working across ClientRouter view transitions; rAF tick state can no longer get stuck.
- Reading-time util strips fenced/inline code, MDX imports, JSX/HTML tags, and image markup before counting for a more accurate estimate.
- Adds `.playwright-mcp/` to `.gitignore` so trace artifacts can't be accidentally committed.

## Test plan
- [ ] Visit a writing post — bar fills as you scroll; "X min read" appears under the title.
- [ ] Click prev/next to confirm the bar still updates after view-transition navigation.
- [ ] Visit a work post (e.g. Synthetic Readings) — bar appears and updates; gated content doesn't break it.
- [ ] Resize so content fits in viewport — bar hides instead of staying at 0%.