### PR TITLE
fix: unify badge typography and use ↗ for external links

### DIFF
--- a/src/components/Pill.astro
+++ b/src/components/Pill.astro
@@ -11,17 +11,17 @@ const { color = 'var(--accent-regular)' } = Astro.props;
 <style>
 	.pill {
 		display: flex;
-		padding: 4px 8px;
+		padding: 0.15rem 0.5rem;
 		gap: 0.5rem;
 		color: var(--accent-text-over);
 		border: 1px solid var(--pill-color, var(--accent-regular));
 		background-color: var(--pill-color, var(--accent-regular));
-		border-radius: 999rem;
-		font-size: 10px;
+		border-radius: 999px;
+		font-size: var(--font-size-xs);
 		line-height: 1.35;
 		white-space: nowrap;
-		text-transform:uppercase;
-		letter-spacing: .0125em;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
 		font-weight: 400;
 	}
 </style>

--- a/src/components/PortfolioPreview.astro
+++ b/src/components/PortfolioPreview.astro
@@ -1,7 +1,7 @@
 ---
 import type { CollectionEntry } from 'astro:content';
 import Pill from '../components/Pill.astro';
-import { ArrowRight, Lock } from '@lucide/astro';
+import { Lock } from '@lucide/astro';
 
 interface Props {
 	project: CollectionEntry<'work'>;
@@ -11,6 +11,7 @@ const { data, id } = Astro.props.project;
 const firstTag = data.tags && data.tags.length > 0 ? data.tags[0] : '';
 const href = data.gated ? `/work/${id}/` : (data.url ?? `/work/${id}/`);
 const cta = data.cta ?? (data.gated ? 'ask for access' : 'view project');
+const isExternal = !data.gated && !!data.url;
 const pillTextColor = firstTag === 'CrossnoKaye' ? '#000' : undefined;
 ---
 
@@ -35,7 +36,7 @@ const pillTextColor = firstTag === 'CrossnoKaye' ? '#000' : undefined;
 			</div>
 			<h3 class="title">{data.title}</h3>
 			<p class="description">{data.description}</p>
-			<span class="faux-button">{cta} <ArrowRight size="1em" /></span>
+			<span class="faux-button">{cta} <span class="arrow">{isExternal ? '↗' : '→'}</span></span>
 		</div>
 	</a>
 </div>


### PR DESCRIPTION
## Summary
- Unifies Pill badge typography/spacing to match the GATED badge style (font-size, letter-spacing, padding) while preserving existing colors and copy
- Replaces ArrowRight icon with ↗ for external links and → for internal links on portfolio cards

## Test plan
- [ ] Verify badge pills (CROSSNOKAYE, UMBRA SPACE, OPENNODE) visually match the GATED badge typography
- [ ] Verify external project links show ↗ and gated/internal links show →
- [ ] Verify badge colors are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)