### PR TITLE
fix: scope intro animation to homepage, play only once per session

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -14,15 +14,23 @@ interface Props {
 	description?: string | undefined;
 	image?: string | undefined;
     useAnimatedBackground?: boolean;
+	useIntroAnimation?: boolean;
 }
 
-const { title, description, image, useAnimatedBackground = false } = Astro.props;
+const { title, description, image, useAnimatedBackground = false, useIntroAnimation = false } = Astro.props;
 ---
 
 <html lang="en">
 	<head>
 		<MainHead title={title} description={description} image={image} />
         <ClientRouter />
+		<script is:inline>
+			(function() {
+				if (sessionStorage.getItem('intro-played')) {
+					document.documentElement.classList.add('intro-played');
+				}
+			})();
+		</script>
 	</head>
 	<body>
 		<div class:list={['flex', 'flex-col', 'backgrounds', 'use-animated-bg']}>
@@ -32,15 +40,26 @@ const { title, description, image, useAnimatedBackground = false } = Astro.props
 			<div transition:persist>
 				<Nav />
 			</div>
-			<div class="animated-fade-in main-content-wrapper">
+			<div class:list={['main-content-wrapper', { 'animated-fade-in': useIntroAnimation }]}>
 				<slot />
 				<Footer />
 			</div>
 		</div>
 
 		<script>
-			// Add "loaded" class once the document has completely loaded.
 			addEventListener('load', () => document.documentElement.classList.add('loaded'));
+
+			function handleIntroAnimation() {
+				const el = document.querySelector('.animated-fade-in');
+				if (!el) return;
+				if (sessionStorage.getItem('intro-played')) {
+					el.classList.remove('animated-fade-in');
+				} else {
+					sessionStorage.setItem('intro-played', 'true');
+				}
+			}
+			handleIntroAnimation();
+			document.addEventListener('astro:after-swap', handleIntroAnimation);
 		</script>
 
 		<style>
@@ -151,6 +170,11 @@ const { title, description, image, useAnimatedBackground = false } = Astro.props
 
 			.animated-fade-in {
 				animation: 1s ease-out forwards fadeInFromTop;
+			}
+
+			:root.intro-played .animated-fade-in {
+				animation: none;
+				opacity: 1;
 			}
 
 			@keyframes fadeInFromTop {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -23,7 +23,7 @@ const projects = (await getCollection('work'))
 const title = "Hi, I'm F Cary Snyder";
 ---
 
-<BaseLayout title={title} useAnimatedBackground={true}>
+<BaseLayout title={title} useAnimatedBackground={true} useIntroAnimation={true}>
 	<div class="flex flex-col full-height-container gap-20">
 		<div class="hero-wrapper">
 			<header class="hero wrapper">


### PR DESCRIPTION
## Summary
- The fade-in animation previously ran on every page load. Now it only plays on the homepage (`index.astro`) and only once per browser session, using `sessionStorage` to track whether it has already played.
- Adds a `useIntroAnimation` prop to `BaseLayout` so pages opt in explicitly.
- Handles both full page loads (inline head script) and View Transition navigations (`astro:after-swap`) to prevent replay.

## Test plan
- [ ] Load the homepage fresh (new tab / incognito) — animation should play once
- [ ] Navigate to another page and back to homepage — animation should NOT replay
- [ ] Hard refresh the homepage after the animation played — animation should NOT replay
- [ ] Close the tab and reopen the site — animation should play again (new session)
- [ ] Verify non-homepage pages never show the animation